### PR TITLE
Add interactive input for Python scripts

### DIFF
--- a/src/core/PythonEngine.cpp
+++ b/src/core/PythonEngine.cpp
@@ -1003,6 +1003,10 @@ void PythonEngine::runScript(const QString &code)
         QMutexLocker lck(&_msgQueueMutex);
         _msgQueue.clear();
     }
+    {
+        QMutexLocker lck(&_inputQueueMutex);
+        _inputQueue.clear();
+    }
 
     emit scriptStarted();
 
@@ -1018,6 +1022,7 @@ void PythonEngine::stopScript()
 {
     _stopRequested = true;
     _msgQueueCondition.wakeAll();
+    _inputQueueCondition.wakeAll();
 
     stopAllPeriodicTasks();
 
@@ -1026,6 +1031,7 @@ void PythonEngine::stopScript()
     for (int i = 0; i < 50 && _running; i++)
     {
         _msgQueueCondition.wakeAll();
+        _inputQueueCondition.wakeAll();
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
@@ -1079,6 +1085,27 @@ void PythonEngine::enqueueMessage(const BusMessage &msg)
         _msgQueue.enqueue(msg);
         _msgQueueCondition.wakeOne();
     }
+}
+
+void PythonEngine::enqueueInput(const QString &text)
+{
+    if (!_running) { return; }
+
+    QMutexLocker lck(&_inputQueueMutex);
+    _inputQueue.enqueue(text.endsWith('\n') ? text : text + '\n');
+    _inputQueueCondition.wakeOne();
+}
+
+std::string PythonEngine::readInputLine()
+{
+    QMutexLocker lck(&_inputQueueMutex);
+    while (_inputQueue.isEmpty() && !_stopRequested.load())
+    {
+        _inputQueueCondition.wait(&_inputQueueMutex);
+    }
+
+    if (_stopRequested.load()) { return {}; }
+    return _inputQueue.dequeue().toUtf8().toStdString();
 }
 
 // ---------------------------------------------------------------------------
@@ -1212,6 +1239,9 @@ void PythonEngine::workerFunc(std::string code)
         globals["_cangaroo_stop_check"] = py::cpp_function(
             [this]() -> bool { return _stopRequested.load(); });
 
+        globals["_cangaroo_input"] = py::cpp_function(
+            [this]() -> std::string { return readInputLine(); });
+
         py::exec(R"(
 import sys
 
@@ -1226,6 +1256,26 @@ class _SignalWriter:
 
 sys.stdout = _SignalWriter(False)
 sys.stderr = _SignalWriter(True)
+
+class _SignalReader:
+    def __init__(self):
+        self._buffer = ""
+    def readline(self, size=-1):
+        if not self._buffer:
+            self._buffer = _cangaroo_input()
+            if not self._buffer and _cangaroo_stop_check():
+                raise KeyboardInterrupt("Script stopped by user")
+        if size is None or size < 0:
+            line, self._buffer = self._buffer, ""
+            return line
+        line, self._buffer = self._buffer[:size], self._buffer[size:]
+        return line
+    def readable(self):
+        return True
+    def isatty(self):
+        return True
+
+sys.stdin = _SignalReader()
 )");
 
         py::exec(R"(

--- a/src/core/PythonEngine.cpp
+++ b/src/core/PythonEngine.cpp
@@ -1240,9 +1240,11 @@ void PythonEngine::workerFunc(std::string code)
             [this]() -> bool { return _stopRequested.load(); });
 
         globals["_cangaroo_input"] = py::cpp_function(
-            [this]() -> std::string { return readInputLine(); });
+            [this]() -> std::string { return readInputLine(); },
+            py::call_guard<py::gil_scoped_release>());
 
         py::exec(R"(
+import io
 import sys
 
 class _SignalWriter:
@@ -1257,8 +1259,9 @@ class _SignalWriter:
 sys.stdout = _SignalWriter(False)
 sys.stderr = _SignalWriter(True)
 
-class _SignalReader:
+class _SignalReader(io.TextIOBase):
     def __init__(self):
+        super().__init__()
         self._buffer = ""
     def readline(self, size=-1):
         if not self._buffer:

--- a/src/core/PythonEngine.h
+++ b/src/core/PythonEngine.h
@@ -48,6 +48,7 @@ public:
     Backend &backend() { return _backend; }
 
     void enqueueMessage(const BusMessage &msg);
+    void enqueueInput(const QString &text);
 
     QMutex &msgQueueMutex() { return _msgQueueMutex; }
     QWaitCondition &msgQueueCondition() { return _msgQueueCondition; }
@@ -88,6 +89,10 @@ private:
     QWaitCondition _msgQueueCondition;
     QQueue<BusMessage> _msgQueue;
 
+    QMutex _inputQueueMutex;
+    QWaitCondition _inputQueueCondition;
+    QQueue<QString> _inputQueue;
+
     // RX filter state
     struct RxFilter
     {
@@ -117,5 +122,6 @@ private:
     int _nextHandle{0};
 
     void workerFunc(std::string code);
+    std::string readInputLine();
     void waitForOrphanedThreadAndSelfDestruct(std::thread worker);
 };

--- a/src/window/ScriptWindow/ScriptWindow.cpp
+++ b/src/window/ScriptWindow/ScriptWindow.cpp
@@ -261,7 +261,6 @@ void ScriptWindow::onScriptStarted()
     _btnStop->setEnabled(true);
     _editor->setReadOnly(true);
     _input->setEnabled(true);
-    _input->setFocus();
 }
 
 void ScriptWindow::onScriptFinished()

--- a/src/window/ScriptWindow/ScriptWindow.cpp
+++ b/src/window/ScriptWindow/ScriptWindow.cpp
@@ -92,12 +92,18 @@ ScriptWindow::ScriptWindow(QWidget *parent, Backend &backend)
     _console->setReadOnly(true);
     _console->setPlaceholderText(tr("Script output..."));
 
+    _input = new QLineEdit(this);
+    _input->setFont(mono);
+    _input->setPlaceholderText(tr("Script input (press Enter to send)..."));
+    _input->setEnabled(false);
+
     _splitter->addWidget(_editor);
     _splitter->addWidget(_console);
     _splitter->setStretchFactor(0, 3);
     _splitter->setStretchFactor(1, 1);
 
     mainLayout->addWidget(_splitter);
+    mainLayout->addWidget(_input);
 
     // Connections
     connect(_btnRun,   &QPushButton::clicked, this, &ScriptWindow::onRunClicked);
@@ -105,6 +111,7 @@ ScriptWindow::ScriptWindow(QWidget *parent, Backend &backend)
     connect(_btnClear, &QPushButton::clicked, this, &ScriptWindow::onClearClicked);
     connect(_btnLoad,  &QPushButton::clicked, this, &ScriptWindow::onLoadClicked);
     connect(_btnSave,  &QPushButton::clicked, this, &ScriptWindow::onSaveClicked);
+    connect(_input, &QLineEdit::returnPressed, this, &ScriptWindow::onInputSubmitted);
     connect(_chkAutoRun, &QCheckBox::toggled, this, [this]() { emit settingsChanged(this); });
 
     connect(_engine, &PythonEngine::scriptOutput,   this, &ScriptWindow::onScriptOutput, Qt::QueuedConnection);
@@ -146,6 +153,7 @@ void ScriptWindow::retranslateUi()
     _btnSave->setText(tr("Save"));
     _chkAutoRun->setText(tr("AutoRun"));
     _chkAutoRun->setToolTip(tr("Start script with measurement"));
+    _input->setPlaceholderText(tr("Script input (press Enter to send)..."));
 }
 
 void ScriptWindow::onRunClicked()
@@ -215,6 +223,19 @@ void ScriptWindow::onSaveClicked()
     }
 }
 
+void ScriptWindow::onInputSubmitted()
+{
+    if (!_engine->isRunning()) { return; }
+
+    const QString text = _input->text();
+    _console->moveCursor(QTextCursor::End);
+    _console->insertPlainText(QStringLiteral("> ") + text + QStringLiteral("\n"));
+    _console->moveCursor(QTextCursor::End);
+    _engine->enqueueInput(text);
+    _input->clear();
+    _input->setFocus();
+}
+
 void ScriptWindow::onScriptOutput(const QString &text)
 {
     _console->moveCursor(QTextCursor::End);
@@ -239,6 +260,8 @@ void ScriptWindow::onScriptStarted()
     _btnRun->setEnabled(false);
     _btnStop->setEnabled(true);
     _editor->setReadOnly(true);
+    _input->setEnabled(true);
+    _input->setFocus();
 }
 
 void ScriptWindow::onScriptFinished()
@@ -247,6 +270,8 @@ void ScriptWindow::onScriptFinished()
     _btnRun->setEnabled(true);
     _btnStop->setEnabled(false);
     _editor->setReadOnly(false);
+    _input->clear();
+    _input->setEnabled(false);
 }
 
 void ScriptWindow::onMeasurementStarted()

--- a/src/window/ScriptWindow/ScriptWindow.h
+++ b/src/window/ScriptWindow/ScriptWindow.h
@@ -50,6 +50,7 @@ private slots:
     void onClearClicked();
     void onLoadClicked();
     void onSaveClicked();
+    void onInputSubmitted();
     void onScriptOutput(const QString &text);
     void onScriptError(const QString &text);
     void onScriptStarted();
@@ -64,6 +65,7 @@ private:
     QSplitter *_splitter;
     QPlainTextEdit *_editor;
     QPlainTextEdit *_console;
+    QLineEdit *_input;
     QPushButton *_btnRun;
     QPushButton *_btnStop;
     QPushButton *_btnClear;


### PR DESCRIPTION
Summary
Adds interactive standard-input support to the embedded Python scripting window.
Python scripts can now pause for and receive user input through APIs such as:
name = input("What is your name? ")
line = sys.stdin.readline()